### PR TITLE
feat(entrypoint): Avoid `value` field in JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ Will produce:
         "amount": 27.27,
         "currency": "EUR"
     },
-    "id": {
-        "value": "fa07c538-8ce4-11ec-9ad5-4f5a625cd744"
-    },
-    "number": {
-        "value": "65 1090 1665 0000 0001 0373 7343"
-    }
+    "id": "fa07c538-8ce4-11ec-9ad5-4f5a625cd744",
+    "number": "65 1090 1665 0000 0001 0373 7343"
 }
 ```
 

--- a/src/main/java/pl/cleankod/ApplicationInitializer.java
+++ b/src/main/java/pl/cleankod/ApplicationInitializer.java
@@ -1,5 +1,6 @@
 package pl.cleankod;
 
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import feign.Feign;
 import feign.httpclient.ApacheHttpClient;
 import feign.jackson.JacksonDecoder;
@@ -9,12 +10,15 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
+import pl.cleankod.exchange.core.domain.Account;
 import pl.cleankod.exchange.core.gateway.AccountRepository;
 import pl.cleankod.exchange.core.gateway.CurrencyConversionService;
 import pl.cleankod.exchange.core.usecase.FindAccountAndConvertCurrencyUseCase;
 import pl.cleankod.exchange.core.usecase.FindAccountUseCase;
 import pl.cleankod.exchange.entrypoint.AccountController;
 import pl.cleankod.exchange.entrypoint.ExceptionHandlerAdvice;
+import pl.cleankod.exchange.serialization.SingleJsonValueInRecordFinder;
+import pl.cleankod.exchange.serialization.SingleValueSerializer;
 import pl.cleankod.exchange.provider.AccountInMemoryRepository;
 import pl.cleankod.exchange.provider.CurrencyConversionNbpService;
 import pl.cleankod.exchange.provider.nbp.ExchangeRatesNbpClient;
@@ -49,6 +53,19 @@ public class ApplicationInitializer {
     }
 
     @Bean
+    public SimpleModule singleValueObjectModule() {
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addSerializer(SingleValueRecordSerializer(Account.Id.class));
+        simpleModule.addSerializer(new SingleValueSerializer<>(Account.Number.class, Account.Number::value));
+
+        return simpleModule;
+    }
+
+    private static <T> SingleValueSerializer<T, Object> SingleValueRecordSerializer(Class<T> recordClass) {
+        return new SingleValueSerializer<>(recordClass, SingleJsonValueInRecordFinder.getAccessorFor(recordClass));
+    }
+
+    @Bean
     FindAccountUseCase findAccountUseCase(AccountRepository accountRepository) {
         return new FindAccountUseCase(accountRepository);
     }
@@ -73,4 +90,5 @@ public class ApplicationInitializer {
     ExceptionHandlerAdvice exceptionHandlerAdvice() {
         return new ExceptionHandlerAdvice();
     }
+
 }

--- a/src/main/java/pl/cleankod/exchange/core/domain/Account.java
+++ b/src/main/java/pl/cleankod/exchange/core/domain/Account.java
@@ -1,5 +1,7 @@
 package pl.cleankod.exchange.core.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import pl.cleankod.util.Preconditions;
 
 import java.util.UUID;
@@ -7,7 +9,7 @@ import java.util.regex.Pattern;
 
 public record Account(Id id, Number number, Money balance) {
 
-    public static record Id(UUID value) {
+    public record Id(@JsonValue UUID value) {
         public Id {
             Preconditions.requireNonNull(value);
         }
@@ -15,14 +17,14 @@ public record Account(Id id, Number number, Money balance) {
         public static Id of(UUID value) {
             return new Id(value);
         }
-
+        @JsonCreator
         public static Id of(String value) {
             Preconditions.requireNonNull(value);
             return new Id(UUID.fromString(value));
         }
     }
 
-    public static record Number(String value) {
+    public record Number(@JsonValue String value) {
         private static final Pattern PATTERN =
                 Pattern.compile("\\d{2}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}[ ]?\\d{4}");
 
@@ -32,7 +34,7 @@ public record Account(Id id, Number number, Money balance) {
                 throw new IllegalArgumentException("The account number does not match the pattern: " + PATTERN);
             }
         }
-
+        @JsonCreator
         public static Number of(String value) {
             return new Number(value);
         }

--- a/src/main/java/pl/cleankod/exchange/serialization/SingleJsonValueInRecordFinder.java
+++ b/src/main/java/pl/cleankod/exchange/serialization/SingleJsonValueInRecordFinder.java
@@ -1,0 +1,59 @@
+package pl.cleankod.exchange.serialization;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Finds single field annotated with @JsonValue annotation for record classes.
+ * Purpose of this class is to mimic what will happen in Jackson library
+ * when it will be able to handle record classes properly.
+ */
+public class SingleJsonValueInRecordFinder<T> {
+
+    private final RecordComponent recordComponent;
+
+    public SingleJsonValueInRecordFinder(Class<T> recordClass) {
+        if (!recordClass.isRecord()) {
+            throw new IllegalArgumentException(
+                String.format("Provided class '%s' is not a record class.", recordClass.getCanonicalName())
+            );
+        }
+
+        List<RecordComponent> componentsWithJsonCreator = Arrays.stream(recordClass.getRecordComponents())
+                .filter(recordComponent -> recordComponent.getAccessor().isAnnotationPresent(JsonValue.class))
+                .toList();
+
+        if (componentsWithJsonCreator.size() != 1) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Provided class '%s' should contain exactly one data field with @JsonValue annotation.",
+                    recordClass.getCanonicalName()
+                )
+            );
+        }
+        this.recordComponent = componentsWithJsonCreator.get(0);
+    }
+
+    private Function<T, Object> wrapAccessorFunction(RecordComponent recordComponent) {
+        return param -> {
+            try {
+                return recordComponent.getAccessor().invoke(param);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+    }
+
+    public Function<T, Object> getAccessor() {
+        return wrapAccessorFunction(recordComponent);
+    }
+
+    public static <T> Function<T, Object> getAccessorFor(Class<T> recordClass) {
+        return new SingleJsonValueInRecordFinder<>(recordClass).getAccessor();
+    }
+}

--- a/src/main/java/pl/cleankod/exchange/serialization/SingleValueSerializer.java
+++ b/src/main/java/pl/cleankod/exchange/serialization/SingleValueSerializer.java
@@ -1,0 +1,28 @@
+package pl.cleankod.exchange.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+public class SingleValueSerializer<T1, T2> extends JsonSerializer<T1> {
+
+    private final Class<T1> handledType;
+    private final Function<T1, T2> valueProvider;
+
+    @Override
+    public Class<T1> handledType() {
+        return handledType;
+    }
+
+    public SingleValueSerializer(Class<T1> handledType, Function<T1, T2> valueProvider) {
+        this.handledType = handledType;
+        this.valueProvider = valueProvider;
+    }
+    @Override
+    public void serialize(T1 value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeObject(valueProvider.apply(value));
+    }
+}

--- a/src/test/groovy/pl/cleankod/exchange/serialization/SingleJsonValueInRecordFinderSpecification.groovy
+++ b/src/test/groovy/pl/cleankod/exchange/serialization/SingleJsonValueInRecordFinderSpecification.groovy
@@ -1,0 +1,41 @@
+package pl.cleankod.exchange.serialization
+
+
+import spock.lang.Specification
+
+class SingleJsonValueInRecordFinderSpecification extends Specification {
+    def "should throw for non record class"() {
+        when:
+        SingleJsonValueInRecordFinder.getAccessorFor(givenClass)
+
+        then:
+        def exception = thrown(IllegalArgumentException)
+        exception.message.endsWith("is not a record class.")
+
+        where:
+        givenClass << [TestClasses.RegularClass.class]
+    }
+
+    def "should throw if class does not contain exactly one JsonValue annotation"() {
+        when:
+        SingleJsonValueInRecordFinder.getAccessorFor(givenClass)
+
+        then:
+        def exception = thrown(IllegalArgumentException)
+        exception.message.endsWith("should contain exactly one data field with @JsonValue annotation.")
+
+        where:
+        givenClass << [TestClasses.RecordClass.class, TestClasses.RecordClassWithMultipleJsonValues.class]
+    }
+
+    def "should find accessor"() {
+        when:
+        def accessor = SingleJsonValueInRecordFinder.getAccessorFor(givenClass)
+
+        then:
+        accessor != null
+
+        where:
+        givenClass << [TestClasses.RecordClassWithJsonValue.class]
+    }
+}

--- a/src/test/groovy/pl/cleankod/exchange/serialization/TestClasses.java
+++ b/src/test/groovy/pl/cleankod/exchange/serialization/TestClasses.java
@@ -1,0 +1,16 @@
+package pl.cleankod.exchange.serialization;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class TestClasses {
+    public static class RegularClass {}
+
+    public record RecordClass() {}
+
+    public record RecordClassWithJsonValue(@JsonValue String value) {
+
+    }
+    public record RecordClassWithMultipleJsonValues(@JsonValue String value1, @JsonValue int value2) {
+
+    }
+}


### PR DESCRIPTION
Account.Id and Account.Number no longer contain `value` field.

Used two approaches to serialization of single value record classes:
1. Uses SingleJsonCreatorInRecordFinder to localize field annotated With @JsonValue annotation. This way better simulates what will be done in Jackson library once handling of record classes will be fixed. Currently, this uses reflection to access accessor method, so it might end up being more costly in runtime. We could add a discovery mechanism for such classes so that we won't need to add anything to singleValueObjectModule method while adding additional single value record class.
2. Uses only SingleValueSerializer and provides handle to accessor method which will be used to serialize value. This method is simpler, but there is nothing that checks that we are using appropriate function (potentially more error-prone).

We should choose one of them - normally, I would have a team discussion about this.

Deserialization is done by adding @JsonCreator annotation to Account.Id and Account.Number classes. As currently there is a release candidate version of Jackson library which contains fixes for handling record classes, I assume that the best approach is not to add anything specific to single value class Serialization/Deserialization in Account.Id/Account.Number classes - this way we would only need to remove `singleValueObjectModule` method while updating Jackson.